### PR TITLE
Override qs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "name": "@intellihr/serverless-node-utils",
   "description": "A serverless utils library",
   "main": "lib/bundle.js",
@@ -45,6 +45,9 @@
     "ignore": [
       "/lib/"
     ]
+  },
+  "resolutions": {
+    "qs": "6.5.3"
   },
   "files": [
     "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,13 +3548,10 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
-qs@6.5.1, qs@^6.0.3, qs@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+qs@6.5.1, qs@6.5.3, qs@^6.0.3, qs@^6.5.1, qs@~6.4.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Patches qs to be 6.5.3 to fix https://nvd.nist.gov/vuln/detail/CVE-2022-24999